### PR TITLE
fix: export symbol and interface to fix type exporting in consuming packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ call(promiseAction.sagas.implement, promiseAction(), () => 2);
 
 `package.json` defines the usual scripts:
 
-* `npm build`: transpiles the source, placing the result in `dist/src/index.js`
+* `npm install`: install node packages.
+* `npm build`: transpiles the source, placing the result in `dist/src/index.js`.
 * `npm test`: builds, and then runs the test suite.
 
 The tests are written using `ts-jest`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,11 @@ import { call } from "redux-saga/effects";
 import { ArgumentError } from "./ArgumentError";
 import { ConfigurationError } from "./ConfigurationError";
 
-const promiseSymbol = Symbol.for("@teroneko/redux-saga-promise");
+export const promiseSymbol = Symbol.for("@teroneko/redux-saga-promise");
 
-type SymbolTagged<T> = { [promiseSymbol]: T };
+export type SymbolTagged<T> = { [promiseSymbol]: T };
 
-type PromiseInstanceFromMeta<V> = {
+export type PromiseInstanceFromMeta<V> = {
   promise?: Promise<V>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const promiseSymbol = Symbol.for("@teroneko/redux-saga-promise");
 
 export type SymbolTagged<T> = { [promiseSymbol]: T };
 
-export type PromiseInstanceFromMeta<V> = {
+type PromiseInstanceFromMeta<V> = {
   promise?: Promise<V>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,11 @@ export const promiseSymbol = Symbol.for("@teroneko/redux-saga-promise");
 
 export type SymbolTagged<T> = { [promiseSymbol]: T };
 
-type PromiseInstanceFromMeta<V> = {
+export type PromiseInstanceFromMeta<V> = {
   promise?: Promise<V>;
 };
 
-type PromiseActionsFromMeta<V, RSA extends PayloadActionCreator<any, any>, RJA extends PayloadActionCreator<any, any>> = {
+export type PromiseActionsFromMeta<V, RSA extends PayloadActionCreator<any, any>, RJA extends PayloadActionCreator<any, any>> = {
   promiseActions: {
     resolved: RSA;
     rejected: RJA;
@@ -31,18 +31,18 @@ type PromiseResolutionFromMeta<V> = {
 
 type ResolvablePromiseActionsFromMeta<V, RSA extends PayloadActionCreator<any, any>, RJA extends PayloadActionCreator<any, any>> = PromiseActionsFromMeta<V, RSA, RJA> & PromiseResolutionFromMeta<V>;
 
-type PromiseActionsFromTriggerAction<TA = any, RSA = any, RJA = any> = {
+export type PromiseActionsFromTriggerAction<TA = any, RSA = any, RJA = any> = {
   trigger: TA;
   resolved: RSA;
   rejected: RJA;
 };
 
-type ActionCreatorWithPreparedPayloadAndMeta<V, P, T extends string, M extends PromiseActionsFromMeta<V, any, any>, PA extends PrepareAction<any>> =
+export type ActionCreatorWithPreparedPayloadAndMeta<V, P, T extends string, M extends PromiseActionsFromMeta<V, any, any>, PA extends PrepareAction<any>> =
   ActionCreatorWithPreparedPayload<Parameters<PA>, P, T, never, ReturnType<PA> extends {
     meta: infer InferM & M;
   } ? InferM : M>;
 
-type PayloadActionAndMeta<V, P, T extends string, M extends PromiseActionsFromMeta<V, any, any>> = PayloadAction<P, T, M, never>;
+export type PayloadActionAndMeta<V, P, T extends string, M extends PromiseActionsFromMeta<V, any, any>> = PayloadAction<P, T, M, never>;
 
 function isTriggerAction(action: PayloadAction<any, any, PromiseActionsFromMeta<any, any, any>>): action is PayloadAction<any, any, ResolvablePromiseActionsFromMeta<any, any, any>> {
   return action?.meta?.promiseActions.resolved != null;
@@ -53,7 +53,7 @@ function verify(action, method) {
   if (!isFunction(action?.meta?.promiseResolution?.resolve)) throw new ConfigurationError(`redux-saga-promise: ${method}: Unable to execute - it seems that the passed action was not processed by the promiseMiddleware. (1. Did you included the promiseMiddlware before SagaMiddleware? 2. Have you dispatched the action to the store before using it?)`);
 }
 
-type ResolveValueFromTriggerAction<A extends PayloadActionAndMeta<any, any, any, any>> = A extends {
+export type ResolveValueFromTriggerAction<A extends PayloadActionAndMeta<any, any, any, any>> = A extends {
   meta: {
     [promiseSymbol]: {
       resolveValueType: infer V
@@ -107,7 +107,7 @@ function createPromiseActions<V, T extends string>(type: T) {
   };
 }
 
-type TriggerExecutor<RT> = (() => PromiseLike<RT> | RT | Iterator<any, RT, any>);
+export type TriggerExecutor<RT> = (() => PromiseLike<RT> | RT | Iterator<any, RT, any>);
 
 function createUpdatedTrigger<V, P, T extends string, TA extends PayloadActionCreator<any, any>>(
   type: T,


### PR DESCRIPTION
I'm trying to use the library and I get TS4023.

> Exported variable 'promiseAction' has or is using name 'promiseSymbol' from external module ".../git/saga-test/node_modules/@teroneko/redux-saga-promise/dist/src/index" but cannot be named.

Minimal example:
```
const promiseAction = promiseActionFactory<string>().simple<string>('ACTION');
export { promiseAction };
```

See https://github.com/microsoft/TypeScript/issues/37888#issuecomment-846638356 for a discussion of the solution.

If I export these types then I have no issues.

